### PR TITLE
remove code enabling transition from remote to local storage

### DIFF
--- a/markasread/background.js
+++ b/markasread/background.js
@@ -1,12 +1,4 @@
 chrome.runtime.onInstalled.addListener(function(details) {
-    if (details.reason == "update") {
-        chrome.storage.sync.get("visited", function(result) {
-            if (result["visited"] !== undefined) {
-                visited = result["visited"];
-                updateDictionary(visited);
-            }
-        })
-    }
     fetchMarkData();
 })
 


### PR DESCRIPTION
Users are assumed to be on version 1.0.0 and using local storage. Therefore, we no longer need to pull links from remote storage, and thus this code is not needed anymore